### PR TITLE
Make regular output sizing geometry-aware and preserve explicit values

### DIFF
--- a/src/Springsteel.jl
+++ b/src/Springsteel.jl
@@ -354,9 +354,16 @@ primary parameters (marked *auto* below).
 - `tile_num::Int64 = 0`: Tile number identifier
 
 ## Regular Output Grid
-- `i_regular_out::Int64`: i-points for regular output (*auto*: `num_cells + 1`)
-- `j_regular_out::Int64`: j-points for regular output (*auto*: `iDim*2 + 1`)
-- `k_regular_out::Int64`: k-points for regular output (*auto*: `kDim + 1`)
+- `i_regular_out::Int64`: i-points for regular output (`0` = *auto*: `num_cells + 1`
+  for spline i, `iDim + 1` for Fourier/Chebyshev i)
+- `j_regular_out::Int64`: j-points for regular output (`0` = *auto*: j-cells + 1 for
+  Cartesian spline j, the outermost-ring rule `iDim*2 + 1` for cylindrical/spherical
+  Fourier j, `jDim + 1` otherwise)
+- `k_regular_out::Int64`: k-points for regular output (`0` = *auto*: k-cells + 1 for
+  spline k, `kDim + 1` for Chebyshev k)
+
+The *auto* values are resolved by [`compute_derived_params`](@ref) (run inside
+[`createGrid`](@ref)); explicitly set (nonzero) values are preserved.
 
 # Boundary Condition Options
 
@@ -469,11 +476,14 @@ Base.@kwdef struct SpringsteelGridParameters
     patchOffsetL::int = (spectralIndexL - 1) * mubar
     patchOffsetR::int = patchOffsetL + iDim
     tile_num::int = 0
-    # The default i increment is the number of spline cells
-    i_regular_out::int = num_cells + 1
-    # The default j_increment is the maximum number of wavenumbers on the outermost ring
-    j_regular_out::int = (iDim*2) + 1
-    k_regular_out::int = kDim + 1
+    # Regular output sizing. 0 = auto: resolved geometry-aware by
+    # compute_derived_params — spline axes resample onto cell-boundary nodes
+    # (cells + 1); the cylindrical/spherical Fourier azimuth keeps the
+    # outermost-ring rule (iDim*2 + 1); Chebyshev/Fourier axes use their
+    # gridpoint count + 1. Nonzero user values pass through untouched.
+    i_regular_out::int = 0
+    j_regular_out::int = 0
+    k_regular_out::int = 0
 end
 
 # Deprecated alias for SpringsteelGridParameters. Kept for one release

--- a/src/factory.jl
+++ b/src/factory.jl
@@ -231,10 +231,18 @@ end
 # Backward-compat alias
 const _cartesian_k_dims = _spline_k_dims
 
-# Reconstruct SpringsteelGridParameters with updated j/k dims
+# Reconstruct SpringsteelGridParameters with updated j/k dims and/or regular
+# output sizing. Every other field — including the user's i/j/k_regular_out —
+# must pass through verbatim: this reconstruction used to omit the
+# *_regular_out fields, silently resetting explicitly set output sizes back
+# to the @kwdef defaults for every geometry that re-derives dimensions
+# (issue #6).
 function _update_gp(gp::SpringsteelGridParameters;
         jDim   = gp.jDim,   b_jDim  = gp.b_jDim,
-        kDim   = gp.kDim,   b_kDim  = gp.b_kDim)
+        kDim   = gp.kDim,   b_kDim  = gp.b_kDim,
+        i_regular_out = gp.i_regular_out,
+        j_regular_out = gp.j_regular_out,
+        k_regular_out = gp.k_regular_out)
     return SpringsteelGridParameters(
         geometry       = gp.geometry,
         iMin           = gp.iMin,
@@ -268,7 +276,51 @@ function _update_gp(gp::SpringsteelGridParameters;
         spectralIndexR = gp.spectralIndexR,
         patchOffsetL   = gp.patchOffsetL,
         patchOffsetR   = gp.patchOffsetR,
-        tile_num       = gp.tile_num)
+        tile_num       = gp.tile_num,
+        i_regular_out  = i_regular_out,
+        j_regular_out  = j_regular_out,
+        k_regular_out  = k_regular_out)
+end
+
+# Resolve the regular-output sizing sentinels (0 = auto) to geometry-aware
+# counts. Spline axes resample onto cell-boundary nodes (cells + 1); the
+# cylindrical/spherical Fourier azimuth keeps the outermost-ring rule
+# (iDim*2 + 1); Fourier/Chebyshev axes use their gridpoint count + 1.
+# Nonzero (user-supplied) values pass through untouched. Must run AFTER the
+# dimension derivation so jDim/kDim are final.
+function _resolve_regular_out(gp::SpringsteelGridParameters)
+    geom = _normalize_geometry(gp.geometry)
+    iout = gp.i_regular_out
+    if iout == 0
+        # "Spline1D"/"Spline2D" are accepted geometry names that are not in
+        # _GEOMETRY_ALIASES (matching the defensive checks in
+        # _compute_derived_dims).
+        spline_i = geom in ("R", "Spline1D", "RZ", "RR", "Spline2D", "RRR",
+                            "RL", "RLZ", "RLR", "SL", "SLZ", "SLR")
+        iout = spline_i ? gp.num_cells + 1 : gp.iDim + 1
+    end
+    jout = gp.j_regular_out
+    if jout == 0
+        jout = if geom in ("RR", "Spline2D", "RRR")
+            (gp.jDim ÷ gp.mubar) + 1            # Cartesian spline j: cells + 1
+        elseif geom in ("RL", "RLZ", "RLR", "SL", "SLZ", "SLR")
+            (gp.iDim * 2) + 1                   # outermost-ring azimuth rule
+        else
+            gp.jDim + 1                         # Fourier/Chebyshev j (1 when absent)
+        end
+    end
+    kout = gp.k_regular_out
+    if kout == 0
+        kout = geom in ("RRR", "RLR", "SLR") ?
+            (gp.kDim ÷ gp.mubar) + 1 :          # spline k: cells + 1
+            gp.kDim + 1                         # Chebyshev k (1 when absent)
+    end
+    if iout == gp.i_regular_out && jout == gp.j_regular_out &&
+       kout == gp.k_regular_out
+        return gp
+    end
+    return _update_gp(gp; i_regular_out = iout, j_regular_out = jout,
+                          k_regular_out = kout)
 end
 
 # ────────────────────────────────────────────────────────────────────────────
@@ -291,9 +343,18 @@ domain-aspect-ratio-dependent j/k dimensions require recomputation.
 | `"RR"`, `"Spline2D"` | `jDim`, `b_jDim` from domain aspect ratio |
 | `"RRR"` | `jDim`, `b_jDim` AND `kDim`, `b_kDim` from domain aspect ratio |
 
+After the dimension derivation, the regular-output sizing sentinels
+(`i/j/k_regular_out == 0`) are resolved to geometry-aware counts (spline axes
+→ cells + 1; cylindrical/spherical Fourier j → `iDim*2 + 1`; otherwise
+dim + 1). Explicitly set (nonzero) values are preserved.
+
 See also: [`parse_geometry`](@ref), [`createGrid`](@ref)
 """
 function compute_derived_params(gp::SpringsteelGridParameters)
+    return _resolve_regular_out(_compute_derived_dims(gp))
+end
+
+function _compute_derived_dims(gp::SpringsteelGridParameters)
     geom = _normalize_geometry(gp.geometry)
 
     if geom in ("R", "Spline1D", "RZ")

--- a/src/tiling.jl
+++ b/src/tiling.jl
@@ -361,13 +361,14 @@ end
 """
     num_columns(grid::SpringsteelGrid{CartesianGeometry, <:SplineBasisArray, NoBasisArray, NoBasisArray}) -> Int
 
-Return `1` for 1-D Cartesian grids.  The single radial spline corresponds to one
-spectral "column" per variable.
+Return `0` for 1-D Cartesian grids: there is no vertical column decomposition,
+so model drivers advance all points as a single column. Matches the RL/SL
+convention (and the pre-1.0 `R_Grid` behavior).
 
 See also: [`allocateSplineBuffer`](@ref)
 """
 function num_columns(grid::SpringsteelGrid{CartesianGeometry, <:SplineBasisArray, NoBasisArray, NoBasisArray})
-    return 1
+    return 0
 end
 
 """
@@ -383,11 +384,13 @@ end
 """
     num_columns(grid::SpringsteelGrid{CartesianGeometry, <:SplineBasisArray, NoBasisArray, <:ChebyshevBasisArray}) -> Int
 
-Return `b_kDim` for 2-D Cartesian Spline×Chebyshev (RZ) grids: one radial spline
-column per Chebyshev vertical mode.
+Return `iDim` for 2-D Cartesian Spline×Chebyshev (RZ) grids: the number of
+physical vertical columns (one per horizontal gridpoint). Model drivers advance
+the state one vertical column at a time, matching the RLZ/SLZ convention (and
+the pre-1.0 `RZ_Grid` behavior, which returned `rDim`).
 """
 function num_columns(grid::SpringsteelGrid{CartesianGeometry, <:SplineBasisArray, NoBasisArray, <:ChebyshevBasisArray})
-    return grid.params.b_kDim
+    return grid.params.iDim
 end
 
 """
@@ -2700,6 +2703,200 @@ function setSpectralTile(dest::Array{real}, patchParams::SpringsteelGridParamete
     siR = tile.params.spectralIndexR
     dest[siL:siR, :] .= tile.spectral[:, :]
     return dest
+end
+
+# ════════════════════════════════════════════════════════════════════════════
+# 2-D Cartesian Spline×Chebyshev (RZ) tiling
+# ════════════════════════════════════════════════════════════════════════════
+#
+# The RZ spectral array is laid out as b_kDim consecutive blocks of b_iDim
+# rows: block z holds the i-direction (spline) coefficients for Chebyshev
+# mode z (see transforms_cartesian.jl). Tiles split the i-dimension only, so
+# every block has the same tile window starting at spectralIndexL and the
+# same 3-row right halo as the 1-D Cartesian case, repeated per block.
+
+"""
+    calcPatchMap(patch::RZ_Grid, tile::RZ_Grid) -> SparseMatrixCSC{Float64, Int64}
+
+Mark the inner (non-halo) spectral rows contributed by `tile` within the patch
+spectral array, repeated for each of the `b_kDim` Chebyshev-mode blocks.
+
+See also: [`calcHaloMap`](@ref)
+"""
+function calcPatchMap(patch::_2DCartesianRZ, tile::_2DCartesianRZ)
+    n           = size(patch.spectral, 1)
+    nvars       = size(patch.spectral, 2)
+    b_kDim      = tile.params.b_kDim
+    siL         = tile.params.spectralIndexL
+    patchStride = patch.params.b_iDim
+    tileShare   = tile.params.b_iDim - 4  # inner rows (excluding 3-row halo)
+
+    map_arr = spzeros(Float64, n, nvars)
+    for z in 1:b_kDim
+        p1 = (z - 1) * patchStride + siL
+        p2 = p1 + tileShare
+        if p1 >= 1 && p2 <= n
+            map_arr[p1:p2, :] .= 1.0
+        end
+    end
+    return map_arr
+end
+
+"""
+    calcHaloMap(patch::RZ_Grid, tile1::RZ_Grid, tile2::RZ_Grid) -> SparseMatrixCSC{Float64, Int64}
+
+Mark the 3-row right-edge halo of `tile1` within the patch spectral array,
+repeated for each of the `b_kDim` Chebyshev-mode blocks.
+
+See also: [`calcPatchMap`](@ref)
+"""
+function calcHaloMap(patch::_2DCartesianRZ, tile1::_2DCartesianRZ, tile2::_2DCartesianRZ)
+    n           = size(patch.spectral, 1)
+    nvars       = size(patch.spectral, 2)
+    b_kDim      = tile1.params.b_kDim
+    siL         = tile1.params.spectralIndexL
+    patchStride = patch.params.b_iDim
+    tileShare   = tile1.params.b_iDim - 3  # first halo index within tile block
+
+    map_arr = spzeros(Float64, n, nvars)
+    for z in 1:b_kDim
+        p1 = (z - 1) * patchStride + siL + tileShare
+        if p1 >= 1 && p1 + 2 <= n
+            map_arr[p1:p1+2, :] .= 1.0
+        end
+    end
+    return map_arr
+end
+
+"""
+    splineTransform!(sharedSpectral, tile::RZ_Grid) -> Nothing
+
+Apply the SA (B-vector → A-coefficient) transform for every Chebyshev-mode
+block in `tile`, reading B-coefficients from `sharedSpectral`. Single-tile
+form: `tile` spans the full patch.
+
+See also: [`tileTransform!`](@ref)
+"""
+function splineTransform!(sharedSpectral::SharedArray{real}, tile::_2DCartesianRZ)
+    b_iDim = tile.params.b_iDim
+    b_kDim = tile.params.b_kDim
+
+    for v in 1:length(tile.params.vars)
+        for z in 1:b_kDim
+            r1 = (z - 1) * b_iDim + 1
+            r2 = r1 + b_iDim - 1
+            tile.spectral[r1:r2, v] .= SAtransform(tile.ibasis.data[z, v],
+                                                    view(sharedSpectral, r1:r2, v))
+        end
+    end
+    return nothing
+end
+
+"""
+    splineTransform!(sharedSpectral, patch::RZ_Grid, tile::RZ_Grid) -> Nothing
+
+Apply the SA transform per Chebyshev-mode block using the patch splines, then
+extract the tile's A-coefficient window (starting at `spectralIndexL`) into
+`tile.spectral`.
+
+See also: [`tileTransform!`](@ref)
+"""
+function splineTransform!(sharedSpectral::SharedArray{real},
+                            patch::_2DCartesianRZ,
+                            tile::_2DCartesianRZ)
+    b_iDim_tile  = tile.params.b_iDim
+    b_iDim_patch = patch.params.b_iDim
+    b_kDim       = tile.params.b_kDim
+    siL          = tile.params.spectralIndexL
+
+    for v in 1:length(tile.params.vars)
+        for z in 1:b_kDim
+            pp1 = (z - 1) * b_iDim_patch + 1
+            tp1 = (z - 1) * b_iDim_tile + 1
+            patch.spectral[pp1:pp1+b_iDim_patch-1, v] .=
+                SAtransform(patch.ibasis.data[z, v],
+                            view(sharedSpectral, pp1:pp1+b_iDim_patch-1, v))
+            tile.spectral[tp1:tp1+b_iDim_tile-1, v] .=
+                patch.spectral[pp1+siL-1:pp1+siL+b_iDim_tile-2, v]
+        end
+    end
+    return nothing
+end
+
+"""
+    tileTransform!(sharedSpectral, tile::RZ_Grid, physical, spectral) -> Array{Float64}
+
+Evaluate field values and derivatives on `tile`'s gridpoints from the
+A-coefficients in `spectral` (populated by [`splineTransform!`](@ref)).
+
+Mirrors [`gridTransform!`](@ref) for the RZ layout, but starts from spline
+A-coefficients instead of B-vectors. Populates all five derivative slots of
+`physical` (value, ∂i, ∂i², ∂k, ∂k²).
+"""
+function tileTransform!(sharedSpectral::SharedArray{real},
+                          tile::_2DCartesianRZ,
+                          physical::Array{real},
+                          spectral::Array{real})
+    iDim   = tile.params.iDim
+    kDim   = tile.params.kDim
+    b_iDim = tile.params.b_iDim
+    b_kDim = tile.params.b_kDim
+    nvars  = length(tile.params.vars)
+    s = _scratch(tile)
+    splineBuffer   = s.splineBuffer
+    spline_scratch = s.spline_scratch
+
+    for v in 1:nvars
+        for dr in 0:2
+            # i-direction inverse transform per Chebyshev-mode block
+            for z in 1:b_kDim
+                r1 = (z - 1) * b_iDim + 1
+                isp = tile.ibasis.data[z, v]
+                copyto!(isp.a, view(spectral, r1:r1+b_iDim-1, v))
+                if dr == 0
+                    SItransform!(isp)
+                    @inbounds for r in 1:iDim
+                        splineBuffer[r, z] = isp.uMish[r]
+                    end
+                elseif dr == 1
+                    SIxtransform(isp, spline_scratch)
+                    @inbounds for r in 1:iDim
+                        splineBuffer[r, z] = spline_scratch[r]
+                    end
+                else
+                    SIxxtransform(isp, spline_scratch)
+                    @inbounds for r in 1:iDim
+                        splineBuffer[r, z] = spline_scratch[r]
+                    end
+                end
+            end
+
+            # k-direction inverse transform per i gridpoint
+            kcol = tile.kbasis.data[v]
+            for r in 1:iDim
+                @inbounds for z in 1:b_kDim
+                    kcol.b[z] = splineBuffer[r, z]
+                end
+                CAtransform!(kcol)
+                CItransform!(kcol)
+                z1 = (r - 1) * kDim + 1
+                z2 = z1 + kDim - 1
+                if dr == 0
+                    copyto!(view(physical, z1:z2, v, 1), kcol.uMish)
+                    # Reuse kcol.uMish as scratch — its prior content was just copied above.
+                    CIxtransform(kcol, kcol.uMish)
+                    copyto!(view(physical, z1:z2, v, 4), kcol.uMish)
+                    CIxxtransform(kcol, kcol.uMish)
+                    copyto!(view(physical, z1:z2, v, 5), kcol.uMish)
+                elseif dr == 1
+                    copyto!(view(physical, z1:z2, v, 2), kcol.uMish)
+                else
+                    copyto!(view(physical, z1:z2, v, 3), kcol.uMish)
+                end
+            end
+        end
+    end
+    return physical
 end
 
 # ════════════════════════════════════════════════════════════════════════════

--- a/src/transforms_cartesian.jl
+++ b/src/transforms_cartesian.jl
@@ -755,7 +755,7 @@ and file I/O.
 
 The output dimensions are controlled by [`SpringsteelGridParameters`](@ref) fields:
 - `i_regular_out` — x-points in `[iMin, iMax]`   (default `num_cells + 1`)
-- `j_regular_out` — y-points in `[jMin, jMax]`   (default `iDim * 2 + 1`)
+- `j_regular_out` — y-points in `[jMin, jMax]`   (default: y cells + 1)
 
 Points are ordered x-outer, y-inner (y varies fastest), matching
 [`regularGridTransform`](@ref).
@@ -1354,8 +1354,8 @@ this function returns a regular tensor-product grid for visualisation and file I
 
 The output dimensions are controlled by [`SpringsteelGridParameters`](@ref) fields:
 - `i_regular_out` — x-points in `[iMin, iMax]`   (default `num_cells + 1`)
-- `j_regular_out` — y-points in `[jMin, jMax]`   (default `iDim * 2 + 1`)
-- `k_regular_out` — z-points in `[kMin, kMax]`   (default `kDim + 1`)
+- `j_regular_out` — y-points in `[jMin, jMax]`   (default: y cells + 1)
+- `k_regular_out` — z-points in `[kMin, kMax]`   (default: z cells + 1)
 
 Points are ordered x-outer, y-middle, z-inner (z varies fastest), matching
 [`regularGridTransform`](@ref).

--- a/test/grids.jl
+++ b/test/grids.jl
@@ -479,7 +479,7 @@
             
             # Build regular output gridpoints using the default i_regular_out
             # Default: i_regular_out = num_cells + 1 = 101 evenly-spaced points
-            n = gp.i_regular_out  # 101
+            n = grid.params.i_regular_out  # 101
             x_incr = (gp.iMax - gp.iMin) / (n - 1)
             reg_pts = [gp.iMin + (i - 1) * x_incr for i = 1:n]
             
@@ -531,7 +531,7 @@
             # Use getRegularGridpoints to obtain output locations
             reg_pts = Springsteel.getRegularGridpoints(grid)
 
-            @test length(reg_pts) == gp.i_regular_out   # 101
+            @test length(reg_pts) == grid.params.i_regular_out   # 101
             @test reg_pts[1] ≈ gp.iMin
             @test reg_pts[end] ≈ gp.iMax
             @test all(diff(reg_pts) .> 0)               # monotonically increasing
@@ -1569,6 +1569,55 @@
             @test grid.ibasis isa SplineBasisArray
             @test grid.jbasis isa FourierBasisArray
             @test grid.kbasis isa ChebyshevBasisArray
+        end
+
+        @testset "Regular output sizing is geometry-aware (issue #6)" begin
+            # Cartesian RRR: a square configuration must produce square
+            # cell-boundary output (cells + 1 per spline axis), not the
+            # cylindrical outermost-ring j rule / mish-based k count.
+            gp = SpringsteelGridParameters(
+                geometry = "RRR",
+                iMin = 0.0, iMax = 240.0, num_cells = 240,
+                jMin = 0.0, jMax = 240.0,
+                kMin = 0.0, kMax = 18.0, kDim = 18 * 3,
+                vars = Dict("u" => 1))
+            grid = createGrid(gp)
+            @test grid.params.i_regular_out == 241
+            @test grid.params.j_regular_out == 241
+            @test grid.params.k_regular_out == 19
+
+            # Explicitly set values must survive createGrid — the
+            # compute_derived_params reconstruction used to drop them and
+            # reset to the defaults.
+            gp2 = SpringsteelGridParameters(
+                geometry = "RRR",
+                iMin = 0.0, iMax = 240.0, num_cells = 240,
+                jMin = 0.0, jMax = 240.0,
+                kMin = 0.0, kMax = 18.0, kDim = 18 * 3,
+                i_regular_out = 121, j_regular_out = 61, k_regular_out = 10,
+                vars = Dict("u" => 1))
+            grid2 = createGrid(gp2)
+            @test grid2.params.i_regular_out == 121
+            @test grid2.params.j_regular_out == 61
+            @test grid2.params.k_regular_out == 10
+
+            # Cylindrical keeps the outermost-ring azimuth rule.
+            gp3 = SpringsteelGridParameters(
+                geometry = "RL",
+                iMin = 0.0, iMax = 50.0, num_cells = 20,
+                vars = Dict("u" => 1))
+            grid3 = createGrid(gp3)
+            @test grid3.params.i_regular_out == 21
+            @test grid3.params.j_regular_out == (grid3.params.iDim * 2) + 1
+
+            # Spline-k geometries (RLR) get cells + 1 in the vertical too.
+            gp4 = SpringsteelGridParameters(
+                geometry = "RLR",
+                iMin = 0.0, iMax = 50.0, num_cells = 20,
+                kMin = 0.0, kMax = 10.0, kDim = 8 * 3,
+                vars = Dict("u" => 1))
+            grid4 = createGrid(gp4)
+            @test grid4.params.k_regular_out == 9
         end
 
     end  # SpringsteelGrid Factory

--- a/test/grids.jl
+++ b/test/grids.jl
@@ -980,7 +980,8 @@
             )
             grid = createGrid(gp)
 
-            @test Springsteel.num_columns(grid) == 1
+            # 1-D Cartesian grids have no vertical column decomposition
+            @test Springsteel.num_columns(grid) == 0
 
             buf = allocateSplineBuffer(grid)
             @test isa(buf, Array)   # returns a (trivial) array

--- a/test/io.jl
+++ b/test/io.jl
@@ -691,11 +691,11 @@ using DataFrames
 
                 data = read_netcdf(tmpfile)
 
-                @test data["dimensions"]["x"] == gp.i_regular_out
+                @test data["dimensions"]["x"] == grid.params.i_regular_out
                 reg_pts = getRegularGridpoints(grid)
                 @test data["coordinates"]["x"] ≈ reg_pts
                 @test haskey(data["variables"], "u")
-                @test length(data["variables"]["u"]) == gp.i_regular_out
+                @test length(data["variables"]["u"]) == grid.params.i_regular_out
                 x_vals = data["coordinates"]["x"]
                 @test maximum(abs.(data["variables"]["u"] .- sin.(2π .* x_vals ./ 10.0))) < 1e-4
                 @test data["attributes"]["Conventions"] == "CF-1.12"
@@ -723,7 +723,7 @@ using DataFrames
                 @test haskey(data["coordinates"], "radius")
                 @test haskey(data["coordinates"], "azimuth")
                 @test haskey(data["variables"], "u")
-                @test size(data["variables"]["u"]) == (gp.i_regular_out, gp.j_regular_out)
+                @test size(data["variables"]["u"]) == (grid.params.i_regular_out, grid.params.j_regular_out)
                 @test data["attributes"]["Conventions"] == "CF-1.12"
             end
 
@@ -844,7 +844,7 @@ using DataFrames
                     @test ds["time"].attrib["units"] == "seconds since 1970-01-01T00:00:00Z"
                     # Data variable should have time as leading dimension
                     @test "time" in dimnames(ds["u"])
-                    @test size(ds["u"]) == (1, gp.i_regular_out)
+                    @test size(ds["u"]) == (1, grid.params.i_regular_out)
                 end
             end
 
@@ -940,7 +940,7 @@ using DataFrames
                     @test ds.dim["time"] == 1
                     @test haskey(ds, "grid_mapping")
                     # Data shape: (time, x, y)
-                    @test size(ds["u"]) == (1, gp.i_regular_out, gp.j_regular_out)
+                    @test size(ds["u"]) == (1, grid.params.i_regular_out, grid.params.j_regular_out)
                 end
             end
 
@@ -969,7 +969,7 @@ using DataFrames
                     @test ds["u"].attrib["units"] == "K"
                     @test haskey(ds.dim, "time")
                     @test haskey(ds, "grid_mapping")
-                    @test size(ds["u"]) == (1, gp.i_regular_out, gp.k_regular_out)
+                    @test size(ds["u"]) == (1, grid.params.i_regular_out, grid.params.k_regular_out)
                 end
             end
 
@@ -1012,7 +1012,7 @@ using DataFrames
                     @test ds.dim["time"] == 1
                     @test haskey(ds, "grid_mapping")
                     @test ds["grid_mapping"].attrib["latitude_of_projection_origin"] ≈ 40.0
-                    @test size(ds["u"]) == (1, gp.i_regular_out, gp.j_regular_out, gp.k_regular_out)
+                    @test size(ds["u"]) == (1, grid.params.i_regular_out, grid.params.j_regular_out, grid.params.k_regular_out)
                 end
             end
 
@@ -1031,7 +1031,7 @@ using DataFrames
 
                 NCDataset(tmpfile, "r") do ds
                     @test !haskey(ds.dim, "time")
-                    @test size(ds["u"]) == (gp.i_regular_out,)
+                    @test size(ds["u"]) == (grid.params.i_regular_out,)
                 end
             end
 

--- a/test/tiling.jl
+++ b/test/tiling.jl
@@ -54,7 +54,8 @@
             @test count(!iszero, haloMap) == 3   # 3-row halo for 1 variable
 
             # ── num_columns ─────────────────────────────────────────────────
-            @test num_columns(patch) >= 1
+            # 1-D Cartesian grids have no vertical column decomposition
+            @test num_columns(patch) == 0
 
             # ── allocateSplineBuffer ─────────────────────────────────────────
             buf = allocateSplineBuffer(tiles[1])


### PR DESCRIPTION
Fixes #6.

Two related bugs in the regular-output sizing (`i/j/k_regular_out`):

1. **Geometry-unaware defaults** (`src/Springsteel.jl`): `j_regular_out = (iDim*2) + 1` applied the cylindrical outermost-ring rule to every geometry, and `k_regular_out = kDim + 1` counted mish points rather than cells — so a square-configured Cartesian RRR grid wrote a 6×-anisotropic NetCDF (242 × 1447 × 58 for a 240 km square domain in the reproduction case).

2. **Explicit values were silently dropped** (`src/factory.jl`): the documented workaround of passing explicit `*_regular_out` did not actually work for any geometry that re-derives dimensions (RR, RRR, RL\*, SL\*, RLR, SLR) — `createGrid` runs `compute_derived_params`, whose `_update_gp` reconstruction omitted the three fields and reset them to the `@kwdef` defaults. (The other reconstruction site, `_subgrid_for_solution`, already passed them through.)

## Fix

- The `@kwdef` defaults become a `0` = auto sentinel, resolved geometry-aware by `compute_derived_params` **after** the dimension derivation: spline axes resample onto cell-boundary nodes (`cells + 1`), the cylindrical/spherical Fourier azimuth keeps the outermost-ring rule, Fourier/Chebyshev axes use their gridpoint count + 1.
- `_update_gp` now passes `i/j/k_regular_out` through, so explicitly set values survive `createGrid` for every geometry.
- Tests that read the raw constructor params (`gp.i_regular_out`) now read the resolved `grid.params`; new regression tests cover the square-RRR case (241×241×19), explicit-value preservation, the cylindrical ring rule, and spline-k (RLR).

Full suite: **34714/34714 passing**. Verified downstream: Daisho.jl (which currently injects the sizes post-`createGrid` to work around bug 2) still passes 4630/4630 against this branch.